### PR TITLE
WIP: Split out `get_state` function

### DIFF
--- a/bot.rs
+++ b/bot.rs
@@ -66,6 +66,11 @@ async fn get_channel_info(ctx: &Context, voice_state: &VoiceState) -> Option<(Ch
     Some((id, member_count))
 }
 
+async fn get_state(ctx: & mut Context) -> & mut BotState {
+    let mut data = ctx.data.write().await;
+    return data.get_mut::<BotStateKey>().unwrap();
+}
+
 #[async_trait]
 impl EventHandler for Handler {
     // When the user types "~voice_notify", start announcing on the corresponding channel.
@@ -74,8 +79,7 @@ impl EventHandler for Handler {
             return;
         }
 
-        let mut data = ctx.data.write().await;
-        let bot_state = data.get_mut::<BotStateKey>().unwrap();
+        let bot_state = get_state(& mut ctx).await;
         bot_state.channel_id = Some(msg.channel_id);
 
         msg.reply(&ctx, "Bot will now announce voice events to this channel!")
@@ -86,8 +90,7 @@ impl EventHandler for Handler {
     // Announce the first time someone joins a voice channel. When subsequent folks join, there is
     // no announcement.
     async fn voice_state_update(&self, ctx: Context, _old: Option<VoiceState>, new: VoiceState) {
-        let mut data = ctx.data.write().await;
-        let bot_state = data.get_mut::<BotStateKey>().unwrap();
+        let bot_state = get_state(& mut ctx).await;
         if bot_state.channel_id.is_none() {
             println!("Ignoring channel event because we didn't receive \"~voice_notify\" command.");
             return;


### PR DESCRIPTION
Why do I get this?
```console
$ bazel run :bot
INFO: Invocation ID: babe1ed8-c386-4911-b344-f05046452179
INFO: Analyzed target //:bot (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: Writing explanation of rebuilds to '/tmp/bazel_explain.log'
ERROR: /home/phil/repos/discord-voice-notification-bot/BUILD:3:12: Compiling Rust bin bot (1 files) failed: (Exit 1): process_wrapper failed: error executing command bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file bazel-out/k8-fastbuild/bin/external/crate_index__libc-0.2.135/libc_build_script.linksearchpaths ... (remaining 188 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error[E0515]: cannot return value referencing local variable `data`
  --> bot.rs:71:12
   |
71 |     return data.get_mut::<BotStateKey>().unwrap();
   |            -----------------------------^^^^^^^^^
   |            |
   |            returns a value referencing data owned by the current function
   |            `data` is borrowed here

error: aborting due to previous error

For more information about this error, try `rustc --explain E0515`.
Target //:bot failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.445s, Critical Path: 0.30s
INFO: 2 processes: 2 internal.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully
```